### PR TITLE
Release crmkit-tool

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,6 +75,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Curated, grouped release notes from the conventional-commit history
+      # (this tag's section only). See cliff.toml.
+      - name: Generate release notes
+        id: notes
+        uses: orhun/git-cliff-action@v4
+        with:
+          config: cliff.toml
+          args: --latest --strip header
+
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
@@ -88,7 +102,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          generate_release_notes: true
+          body: ${{ steps.notes.outputs.content }}
           files: |
             dist/*.tar.gz
             dist/checksums.txt

--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -46,6 +46,27 @@ jobs:
             echo "Tag v${{ steps.version.outputs.version }} does not exist"
           fi
 
+      # Regenerate CHANGELOG.md from the conventional-commit history (treating the
+      # not-yet-tagged commits as this release) and commit it to main, so the tag
+      # below points at a commit with an up-to-date changelog. See cliff.toml.
+      - name: Update changelog
+        if: steps.check_tag.outputs.exists == 'false'
+        uses: orhun/git-cliff-action@v4
+        with:
+          config: cliff.toml
+          args: --tag v${{ steps.version.outputs.version }} -o CHANGELOG.md
+
+      - name: Commit changelog
+        if: steps.check_tag.outputs.exists == 'false'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if ! git diff --quiet -- CHANGELOG.md; then
+            git add CHANGELOG.md
+            git commit -m "docs: update changelog for v${{ steps.version.outputs.version }} [skip ci]"
+            git push origin HEAD:main
+          fi
+
       - name: Create and push tag
         if: steps.check_tag.outputs.exists == 'false'
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog
+
+All notable changes to crmkit. Generated from conventional commits by [git-cliff](https://git-cliff.org).
+
+## [0.2.0] - 2026-06-07
+
+### Features
+
+- Implement optimistic concurrency control with versioning for contacts, companies, and deals
+- Implement detailed audit logging with filtering by target and record history
+- Update confirmation messages to use stable internal IDs for deletions
+
+## [0.1.11] - 2026-06-07
+
+### Features
+
+- Introduce short, workspace-scoped public handles for CRM records
+
+## [0.1.10] - 2026-06-07
+
+### Features
+
+- Add tags support for companies and contacts, including filtering
+- Implement custom-field filtering for companies and deals
+- Harden query parsing against SQL injection (cursor validation + safety coverage)
+- Enhance company management with notes and activity logging
+- Implement activity deletion and activity-quota management
+- Implement audit-log retention with pruning
+
+## [0.1.9] - 2026-06-06
+
+The initial public line of crmkit - an agent-first, headless CRM driven over a
+plain-text HTTP API, with an MCP connector for chat clients.
+
+### Features
+
+- Core CRM: contacts, companies, deals, and activities, all workspace-scoped
+- Cross-entity search across contacts, companies, and deals
+- Per-workspace timezone with localized date display
+- `created_by` attribution and activity summaries on records, with filtering by creator
+- Audit entries attributed to the acting member (human or agent)
+- Create a workspace during the OAuth authorization flow
+- OTP auth with bearer tokens, MCP connector, and per-plan resource limits

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,61 @@
+# git-cliff configuration (https://git-cliff.org).
+#
+# Turns the conventional-commit history (feat:/fix:/perf:/...) into curated
+# release notes: CHANGELOG.md is maintained by the tag workflow, and each GitHub
+# Release body is the latest section. Only user-facing groups are shown; chores,
+# CI, tests, docs, refactors, version bumps, and automation noise are filtered.
+
+[changelog]
+header = """
+# Changelog
+
+All notable changes to crmkit. Generated from conventional commits by \
+[git-cliff](https://git-cliff.org).
+"""
+body = """
+{% if version -%}
+## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else -%}
+## [unreleased]
+{% endif -%}
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | striptags | trim | upper_first }}
+{% for commit in commits %}
+- {{ commit.message | upper_first }}
+{%- endfor %}
+{% endfor %}
+"""
+trim = true
+footer = ""
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+filter_commits = true
+topo_order = false
+sort_commits = "oldest"
+tag_pattern = "v[0-9].*"
+
+# First match wins, so the noise-skips precede the grouping rules. The HTML
+# comment prefixes on group names only set ordering (Features < Fixes < Perf);
+# the template strips them with `striptags`.
+commit_parsers = [
+  # Drop automation / housekeeping noise (these are still in git history).
+  { message = "(?i)^(feat|chore)(\\(.*\\))?:?\\s*(bump|update) version", skip = true },
+  { message = "(?i)update version to", skip = true },
+  { message = "(?i)stage uncommitted changes from copilot", skip = true },
+  # README/marketing edits are sometimes committed as feat:; they aren't product
+  # changes, so keep them out of release notes.
+  { message = "(?i)readme", skip = true },
+  { message = "^chore", skip = true },
+  { message = "^ci", skip = true },
+  { message = "^test", skip = true },
+  { message = "^docs", skip = true },
+  { message = "^refactor", skip = true },
+  { message = "^style", skip = true },
+  { message = "^build", skip = true },
+  # User-facing groups.
+  { message = "^feat", group = "<!-- 0 -->Features" },
+  { message = "^fix", group = "<!-- 1 -->Bug Fixes" },
+  { message = "^perf", group = "<!-- 2 -->Performance" },
+]


### PR DESCRIPTION
Automated release from monorepo.

Pushed from `incubator/crmkit/tool` on branch `next` → `main`.